### PR TITLE
added 'lanes' key in data, fix NoKeyError

### DIFF
--- a/tools/detect.py
+++ b/tools/detect.py
@@ -25,7 +25,7 @@ class Detect(object):
     def preprocess(self, img_path):
         ori_img = cv2.imread(img_path)
         img = ori_img[self.cfg.cut_height:, :, :].astype(np.float32)
-        data = {'img': img}
+        data = {'img': img, 'lanes': []}
         data = self.processes(data)
         data['img'] = data['img'].unsqueeze(0)
         data.update({'img_path':img_path, 'ori_img':ori_img})


### PR DESCRIPTION
**Error before change :** 

In detect.py [#L28](https://github.com/Turoad/lanedet/blob/367522c3e1aa8beb41c928005faf97388194d02a/tools/detect.py#L28) the data dict does not have any 'lanes' key, which is referenced in datasets/process/generate_lane_line.py [#L127](https://github.com/Turoad/lanedet/blob/367522c3e1aa8beb41c928005faf97388194d02a/lanedet/datasets/process/generate_lane_line.py#L127). Running the current code displays the following error:

<pre>Traceback (most recent call last):
  File "tools/detect.py", line 84, in <module>
    process(args)
  File "tools/detect.py", line 73, in process
    detect.run(p)
  File "tools/detect.py", line 47, in run
    data = self.preprocess(data)
  File "tools/detect.py", line 29, in preprocess
    data = self.processes(data)
  File "/media/crimson/Dataset/BoltuData/Lane Detection/lanedet/lanedet/datasets/process/process.py", line 35, in __call__
    data = t(data)
  File "/media/crimson/Dataset/BoltuData/Lane Detection/lanedet/lanedet/datasets/process/generate_lane_line.py", line 127, in __call__
    line_strings_org = self.lane_to_linestrings(sample['lanes'])
KeyError: 'lanes'</pre>

**Bug Fix :** 

Added an empty dict with key 'lanes' to the **data** dict in [#L28](https://github.com/Turoad/lanedet/blob/367522c3e1aa8beb41c928005faf97388194d02a/tools/detect.py#L28)