### PR TITLE
fix No module named 'torchvision.models.utils' error

### DIFF
--- a/lanedet/models/backbones/mobilenet.py
+++ b/lanedet/models/backbones/mobilenet.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 from torch import Tensor
-from torchvision.models.utils import load_state_dict_from_url
+from torch.hub import load_state_dict_from_url
 from typing import Callable, Any, Optional, List
 
 from lanedet.models.registry import BACKBONES

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch==1.6.0
-torchvision==0.7.0
+torch==1.9.0
+torchvision==0.10.0
 pandas
 addict
 sklearn


### PR DESCRIPTION
Error when running `detect.py`

Error message: 
```
  File "<directory_to_lanedet>/lanedet/lanedet/models/backbones/mobilenet.py", line 4, in <module>
    from torchvision.models.utils import load_state_dict_from_url
ModuleNotFoundError: No module named 'torchvision.models.utils'
```
torchvision verison = 0.11.1

Using `from torch.hub import load_state_dict_from_url` fixed the problem.